### PR TITLE
Added abiliy to grow in both directions up to a max.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you want to use this in your own javascript projects, you need something like
 
     <script src='packer.growing.js'></script>
     <script>
-      var packer = new Packer(1000, 1000);   // or:  new GrowingPacker();
+      var packer = new Packer(1000, 1000); // or:  new GrowingPacker(1000,1000);
       var blocks = [
         { w: 100, h: 100 },
         { w: 100, h: 100 },

--- a/css/demo.css
+++ b/css/demo.css
@@ -1,5 +1,6 @@
 
-#settings                  { width: 12em; padding: 1em; display: inline-block; float: left; border: 1px solid #999; background-color: #EEE; }
+#main                      { position: relative; margin: 0; padding: 0; }
+#settings                  { width: 12em; padding: 1em; display: inline-block; border: 1px solid #999; background-color: #EEE; position: absolute; left: 0em; }
 #settings .examples        { margin-bottom: 1em; }
 #settings .blocks          { }
 #settings .blocks .example { color: #999; font-style: italic; float: right; margin-right: 1em; }
@@ -9,8 +10,8 @@
 #settings .ratio           { clear: both; border: 1px solid #999; padding: 1em; }
 #settings .nofit           { display: none; border: 1px solid red; margin-top: 1em; padding: 1em; }
 
-#packing                   { margin-left: 15em; }
-#canvas                    { background-color: #FBFBFB; }
+#packing                   { margin: 0 1em; position: absolute; left: 14em; overflow: scroll; }
+#canvas                    { background-color: #FBFBFB; border: 1px solid black; }
 #unsupported               { border: 1px solid red; background-color: #FFFFAD; padding: 1em; margin: 1em; }
 
 textarea { resize: none; }

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 
   <h1>Bin Packing Algorithm</h1>
 
+  <div id="main">
   <div id="settings">
 
     <div class='examples'>
@@ -78,6 +79,7 @@
         Sorry, this example cannot be run because your browser does not support the &lt;canvas&gt; element
       </div>
     </canvas>
+  </div>
   </div>
 
   <script src='js/jquery.js'>        </script>

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
       <select id='size'>
         <option>500x500</option>
         <option>800x600</option>
+        <option>columns</option>
         <option selected>automatic</option>
       </select>
     </div>
@@ -85,6 +86,7 @@
   <script src='js/jquery.js'>        </script>
   <script src='js/packer.js'>        </script>
   <script src='js/packer.growing.js'></script>
+  <script src='js/packer.cols.js'></script>
   <script src='js/demo.js'>          </script>
 
 </body>

--- a/js/demo.js
+++ b/js/demo.js
@@ -62,7 +62,8 @@ Demo = {
 
     Demo.canvas.reset(packer.root.w, packer.root.h);
     Demo.canvas.blocks(blocks);
-    Demo.canvas.boundary(packer.root);
+    if(Demo.el.size.val() != 'automatic')
+        Demo.canvas.boundary(packer.root);
     Demo.report(blocks, packer.root.w, packer.root.h);
   },
 
@@ -71,7 +72,13 @@ Demo = {
   packer: function() {
     var size = Demo.el.size.val();
     if (size == 'automatic') {
-      return new GrowingPacker();
+      var outer = $("#packing");
+      var pos   = outer.offset();
+      var win   = $(window);
+      var sz = { w: win.width() - pos.left,
+                 h: win.height() - pos.top};
+      outer.width(sz.w); outer.height(sz.h);
+      return new GrowingPacker(sz.w, sz.h);
     }
     else {
       var dims = size.split("x");

--- a/js/packer.cols.js
+++ b/js/packer.cols.js
@@ -1,0 +1,180 @@
+/******************************************************************************
+
+This is a column layout algorithm that positions
+blocks within columns to achieve a ratio as
+close to the input as possible.
+
+Each object has a single height and multiple widths,
+representing vertical divisions within a column.
+This is to accomodate columns within columns --
+for example titles on the left and items on the right.
+
+Best results occur when the input blocks are sorted by height, or even better
+when sorted by max(width,height).
+
+Inputs:
+------
+
+    n : number of sub-columns within each column
+    r : target ratio of width per height
+    blocks: [ {
+                h: Number,
+                w: [ Number ] -- w.length === n (const. for all blocks)
+            } ]
+      
+
+Outputs:
+-------
+
+  col_widths : [ [ Number] ]
+          -- Widths of each sub-column.
+          col_widths.length === number of columns
+          col_widths[i].length === n
+
+  marks each block that fits with a .fit attribute containing
+  { col : Int, -- assigned column number (index of col_widths)
+    y   : Number -- vertical position of top of block
+  }
+
+Example:
+-------
+
+  var blocks = [
+    { w: [100], h: 100 },
+    { w: [100], h: 100 },
+    { w: [ 80], h:  80 },
+    { w: [ 80], h:  80 },
+    { w: [ 98], h:  59 },
+    { w: [102], h:  44 }
+  ];
+
+  var layout = new ColLayout(1, 1.381); // input is desired width / height
+  layout.assign(blocks);
+
+  const x = layout.colStarts();
+
+  blocks.forEach(function(block) {
+      Draw(x[block.fit.col][0], block.fit.y, block.w[0], block.h);
+  });
+
+
+******************************************************************************/
+
+// given:
+//   [starting widths]
+//   [new widths]
+// returns
+//  - sum of empty widths
+//  - sum of expansion widths
+function maxExpand(w1, w2) {
+    var ret = [0,0];
+    for(var i=0; i<w1.length; i++) {
+        if(w1[i] >= w2[i]) // empty
+            ret[0] += w1[i] - w2[i];
+        else // expand
+            ret[1] += w2[i] - w1[i];
+    }
+    return ret;
+}
+
+// Area of perfect enclosing rect.
+function area(r, w,h) {
+    return w < r*h ? r*h*h : w*w/r;
+}
+
+ColLayout = function(n, r) {
+    this.init(n, r);
+};
+
+ColLayout.prototype = {
+  // Internally, this function always
+  // maintains an "empty" last column.
+  init: function(n, r) {
+    this.wid = 0;
+    this.ht  = 0;
+    this.cols = [ Array(n).fill(0) ];
+    this.n = n;
+    this.r = r;
+    this.vert = [ 0 ]; // vert. space used within ea. col.
+  },
+
+  assign: function(blocks) {
+    blocks.forEach(this.add.bind(this));
+  },
+
+  // Calculate the increase in 'empty' space,
+  // given by this placement.
+  // The formula is always Delta A - w*h.
+  //
+  // However, we also add permanently 'lost' space
+  // due to expansion / unrealized contraction of widths.
+  cost: function(i, w, h) {
+      const expand = maxExpand(this.cols[i], w);
+      const wid = this.wid + expand[1]; // final total width
+      let ht = h + this.vert[i];
+      ht = ht < this.ht ? this.ht : ht; // final total height
+      const A = area(this.r, wid, ht); // old area + diff. in area
+
+      // Double-count permanently 'lost' space.
+      return A + h*expand[0] + this.vert[i]*expand[1];
+  },
+
+  // Determine 'best' column based
+  // on the internal cost function :
+  // (col#, w, h) => penalty
+  //
+  // It does not modify the state.
+  findBest: function(w, h) {
+      let best = Infinity, col=0;
+      const _this = this;
+      this.cols.forEach(function(wid, i) {
+          const c = _this.cost(i, w, h);
+          if(c < best) {
+              best = c;
+              col = i;
+          }
+      });
+      return col;
+  },
+
+  // add the given block
+  add: function(block) {
+      const col = this.findBest(block.w, block.h);
+
+      block.fit = { col, y: this.vert[col] };
+
+      if(col === this.cols.length-1) {
+          this.cols.push(Array(this.n).fill(0)); // new empty col.
+          this.vert.push(0);
+      }
+
+      // Update dimensions.
+      let expand = 0; // total width expansion
+      for(var i=0; i<this.n; i++) {
+          const delta = block.w[i] - this.cols[col][i];
+          if(delta > 0) {
+              expand += delta;
+              this.cols[col][i] += delta;
+          }
+      }
+      this.wid += expand;
+      this.vert[col] += block.h;
+      this.ht = Math.max(this.ht, this.vert[col]);
+  },
+
+  colStarts: function() {
+      let x0 = 0.0;
+      let x = [];
+
+      this.cols.forEach(function(wid) {
+          let x1 = [];
+          wid.forEach(function(w) {
+             x1.push(x0);
+             x0 += w;
+          });
+          x.push(x1);
+      });
+      return x;
+  }
+}
+

--- a/js/packer.growing.js
+++ b/js/packer.growing.js
@@ -1,22 +1,16 @@
 /******************************************************************************
 
 This is a binary tree based bin packing algorithm that is more complex than
-the simple Packer (packer.js). Instead of starting off with a fixed width and
-height, it starts with the width and height of the first block passed and then
-grows as necessary to accomodate each subsequent block. As it grows it attempts
-to maintain a roughly square ratio by making 'smart' choices about whether to
-grow right or down.
+the simple Packer (packer.js).  It makes fewer cuts by leaving open space
+between the already-cut (and allocated) areas and the maximum container
+size.  Instead of starting off with a fixed width and
+height, the cutting area starts with the width and height of the
+first block passed and then grows into the unallocated space
+as necessary to accomodate each subsequent block.
+When it needs to grow, it puts the new block on the side that makes
+the final dimensions closest to the proportions of the enclosing area.
 
-When growing, the algorithm can only grow to the right OR down. Therefore, if
-the new block is BOTH wider and taller than the current target then it will be
-rejected. This makes it very important to initialize with a sensible starting
-width and height. If you are providing sorted input (largest first) then this
-will not be an issue.
-
-A potential way to solve this limitation would be to allow growth in BOTH
-directions at once, but this requires maintaining a more complex tree
-with 3 children (down, right and center) and that complexity can be avoided
-by simply chosing a sensible starting block.
+The algorithm can grow eigher right OR down as size permits.
 
 Best results occur when the input blocks are sorted by height, or even better
 when sorted by max(width,height).
@@ -44,7 +38,8 @@ Example:
     etc
   ];
 
-  var packer = new GrowingPacker();
+  // For essentially unbounded area:
+  var packer = new GrowingPacker(10000, 10000);
   packer.fit(blocks);
 
   for(var n = 0 ; n < blocks.length ; n++) {
@@ -57,31 +52,39 @@ Example:
 
 ******************************************************************************/
 
-GrowingPacker = function() { };
+GrowingPacker = function(w, h) {
+  this.init(w, h);
+};
 
 GrowingPacker.prototype = {
 
+  init: function(w, h) {
+    //console.log("avail: " + w+" x "+h);
+    this.maxw = w;
+    this.maxh = h;
+    this.root = { x: 0, y: 0, w: 0, h: 0 };
+  },
+
+
   fit: function(blocks) {
     var n, node, block, len = blocks.length;
-    var w = len > 0 ? blocks[0].w : 0;
-    var h = len > 0 ? blocks[0].h : 0;
-    this.root = { x: 0, y: 0, w: w, h: h };
+
     for (n = 0; n < len ; n++) {
       block = blocks[n];
       if (node = this.findNode(this.root, block.w, block.h))
         block.fit = this.splitNode(node, block.w, block.h);
       else
-        block.fit = this.growNode(block.w, block.h);
+        block.fit = this.grow(block.w, block.h);
     }
   },
 
   findNode: function(root, w, h) {
-    if (root.used)
-      return this.findNode(root.right, w, h) || this.findNode(root.down, w, h);
-    else if ((w <= root.w) && (h <= root.h))
-      return root;
-    else
+    if(w > root.w || h > root.h) // early search termination
       return null;
+    if(root.used)
+      return this.findNode(root.right, w, h) || this.findNode(root.down, w, h);
+
+    return root;
   },
 
   splitNode: function(node, w, h) {
@@ -91,12 +94,15 @@ GrowingPacker.prototype = {
     return node;
   },
 
-  growNode: function(w, h) {
-    var canGrowDown  = (w <= this.root.w);
-    var canGrowRight = (h <= this.root.h);
+  grow: function(w, h) {
+    const rem_w = this.maxw - (this.root.w + w),
+          rem_h = this.maxh - (this.root.h + h);
+    var canGrowRight = rem_w >= 0 && h <= this.maxh;
+    var canGrowDown  = rem_h >= 0 && w <= this.maxw;
 
-    var shouldGrowRight = canGrowRight && (this.root.h >= (this.root.w + w)); // attempt to keep square-ish by growing right when height is much greater than width
-    var shouldGrowDown  = canGrowDown  && (this.root.w >= (this.root.h + h)); // attempt to keep square-ish by growing down  when width  is much greater than height
+    var shouldGrowRight = canGrowRight && (rem_w >= rem_h);
+    var shouldGrowDown  = canGrowDown  && (rem_w <= rem_h);
+
 
     if (shouldGrowRight)
       return this.growRight(w, h);
@@ -113,33 +119,39 @@ GrowingPacker.prototype = {
   growRight: function(w, h) {
     this.root = {
       used: true,
-      x: 0,
+      x: this.root.w,
       y: 0,
       w: this.root.w + w,
       h: this.root.h,
-      down: this.root,
-      right: { x: this.root.w, y: 0, w: w, h: this.root.h }
+      right: this.root, // really left
+      down: { x: this.root.w, y: h, w: w, h: this.root.h-h }
     };
-    if (node = this.findNode(this.root, w, h))
-      return this.splitNode(node, w, h);
-    else
-      return null;
+    if(h > this.root.h) { // grow both directions
+        this.root.down = { x: 0, y: this.root.h,
+                           w: this.root.w, h: h - this.root.h };
+        this.root.h = h;
+    }
+    //console.log(this.root.w+ " x " + this.root.h);
+    return this.root;
   },
 
   growDown: function(w, h) {
     this.root = {
       used: true,
       x: 0,
-      y: 0,
+      y: this.root.h,
       w: this.root.w,
       h: this.root.h + h,
-      down:  { x: 0, y: this.root.h, w: this.root.w, h: h },
-      right: this.root
+      right:  { x: w, y: this.root.h, w: this.root.w - w, h: h },
+      down: this.root // really up
     };
-    if (node = this.findNode(this.root, w, h))
-      return this.splitNode(node, w, h);
-    else
-      return null;
+    if(w > this.root.w) {
+        this.root.right = { x: this.root.w, y: 0,
+                            w: w - this.root.w, h: this.root.h };
+        this.root.w = w;
+    }
+    //console.log(this.root.w+ " x " + this.root.h);
+    return this.root;
   }
 
 }

--- a/js/packer.growing.js
+++ b/js/packer.growing.js
@@ -62,9 +62,7 @@ GrowingPacker.prototype = {
     //console.log("avail: " + w+" x "+h);
     this.maxw = w;
     this.maxh = h;
-    this.root = { x: 0, y: 0, w: 0, h: 0,
-                  right: { w: 0, h: 0},
-                  left:  { w: 0, h: 0} };
+    this.root = { x: 0, y: 0, w: 0, h: 0 };
   },
 
 
@@ -73,9 +71,6 @@ GrowingPacker.prototype = {
   },
 
   add: function(block) {
-    if(!this.root.used) {
-        block.fit = this.growDown(block.w, block.h);
-    }
     const node = this.findNode(this.root, block.w, block.h);
     if (node)
       block.fit = this.splitNode(node, block.w, block.h);
@@ -133,7 +128,8 @@ GrowingPacker.prototype = {
     };
     if(h > this.root.h) { // grow both directions
         this.root.down = { x: 0, y: this.root.h,
-                           w: this.root.w, h: h - this.root.h };
+                           w: this.root.w - w,
+                           h: h - this.root.h };
         this.root.h = h;
     }
     //console.log(this.root.w+ " x " + this.root.h);
@@ -152,7 +148,8 @@ GrowingPacker.prototype = {
     };
     if(w > this.root.w) {
         this.root.right = { x: this.root.w, y: 0,
-                            w: w - this.root.w, h: this.root.h };
+                            w: w - this.root.w,
+                            h: this.root.h-h };
         this.root.w = w;
     }
     //console.log(this.root.w+ " x " + this.root.h);

--- a/js/packer.growing.js
+++ b/js/packer.growing.js
@@ -62,20 +62,25 @@ GrowingPacker.prototype = {
     //console.log("avail: " + w+" x "+h);
     this.maxw = w;
     this.maxh = h;
-    this.root = { x: 0, y: 0, w: 0, h: 0 };
+    this.root = { x: 0, y: 0, w: 0, h: 0,
+                  right: { w: 0, h: 0},
+                  left:  { w: 0, h: 0} };
   },
 
 
   fit: function(blocks) {
-    var n, node, block, len = blocks.length;
+    blocks.forEach(this.add.bind(this));
+  },
 
-    for (n = 0; n < len ; n++) {
-      block = blocks[n];
-      if (node = this.findNode(this.root, block.w, block.h))
-        block.fit = this.splitNode(node, block.w, block.h);
-      else
-        block.fit = this.grow(block.w, block.h);
+  add: function(block) {
+    if(!this.root.used) {
+        block.fit = this.growDown(block.w, block.h);
     }
+    const node = this.findNode(this.root, block.w, block.h);
+    if (node)
+      block.fit = this.splitNode(node, block.w, block.h);
+    else
+      block.fit = this.grow(block.w, block.h);
   },
 
   findNode: function(root, w, h) {
@@ -113,7 +118,7 @@ GrowingPacker.prototype = {
     else if (canGrowDown)
       return this.growDown(w, h);
     else
-      return null; // need to ensure sensible root starting size to avoid this happening
+      return null;
   },
 
   growRight: function(w, h) {

--- a/js/packer.js
+++ b/js/packer.js
@@ -66,12 +66,11 @@ Packer.prototype = {
   },
 
   findNode: function(root, w, h) {
+    if(w > root.w || h > root.h) // early search termination
+        return null;
     if (root.used)
       return this.findNode(root.right, w, h) || this.findNode(root.down, w, h);
-    else if ((w <= root.w) && (h <= root.h))
-      return root;
-    else
-      return null;
+    return root;
   },
 
   splitNode: function(node, w, h) {


### PR DESCRIPTION
The GrowingPacker can now add elements that exceed both the width and height of the root container.  It does this by replacing the root with a new root whose (x,y) origin points at the newly added space.

This breaks the assumption that the (x,y) origin is always at the top-left of each node.  Instead, the (x,y) origin is always somewhere within the node.  Of course, the width and height still always represent the total area "owned" by each node.  This has been used to terminate the "fits-inside" traversal early by skipping dead-ends when a node is smaller than the new element to add.

Finally, the growing packer demo has been changed to grow up to the max width and height available to the canvas area.